### PR TITLE
#6 Fixed the issue where solr reindex would be duplicated

### DIFF
--- a/freya/freya-annotate/src/main/java/org/freya/service/SolrIndexService.java
+++ b/freya/freya-annotate/src/main/java/org/freya/service/SolrIndexService.java
@@ -1,5 +1,9 @@
 package org.freya.service;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
 import org.freya.index.solr.TripleIndexer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,12 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.security.Principal;
-
 
 @Controller
 @RequestMapping("solr")
@@ -24,15 +22,16 @@ public class SolrIndexService {
     private TripleIndexer tripleIndexer;
 
     @RequestMapping(value = "/reindex", method = RequestMethod.POST)
-    public void reindex(HttpServletResponse response, Principal principal) throws IOException {
+    public void reindex(HttpServletResponse response) throws IOException {
         PrintWriter out = response.getWriter();
         response.setContentType("text/html");
         final long start = System.currentTimeMillis();
         try {
             out.write("<div>Start reindexing ... </div>");
             out.flush();
+            tripleIndexer.clear();
             tripleIndexer.indexAll();
-        } catch(Exception e) {
+        } catch (Exception e) {
             log.error("Error while reindexing", e);
             out.write(e.getLocalizedMessage());
         } finally {
@@ -42,9 +41,9 @@ public class SolrIndexService {
             out.close();
         }
     }
-    
+
     @RequestMapping(value = "/clear", method = RequestMethod.POST)
-    public void clear(HttpServletResponse response, Principal principal) throws IOException {
+    public void clear(HttpServletResponse response) throws IOException {
         PrintWriter out = response.getWriter();
         response.setContentType("text/html");
         final long start = System.currentTimeMillis();
@@ -52,7 +51,7 @@ public class SolrIndexService {
             out.write("<div>Start clearing ... </div>");
             out.flush();
             tripleIndexer.clear();
-        } catch(Exception e) {
+        } catch (Exception e) {
             log.error("Error while clearing", e);
             out.write(e.getLocalizedMessage());
         } finally {


### PR DESCRIPTION
This issue was caused by two reasons.
1. The deletion before reindex was not commit properly.
2. The SolrInputDocument list was not clear after reindex finished. This is the main reason why reindex would be duplicated.

The reindex operation now improved by using ExecutorService to ensure concurrency. 

Build Results:

```
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] freya .............................................. SUCCESS [  0.735 s]
[INFO] freya .............................................. SUCCESS [ 21.133 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 22.079 s
[INFO] Finished at: 2015-11-12T21:55:52+00:00
[INFO] Final Memory: 21M/245M
[INFO] ------------------------------------------------------------------------
```
