### PR TITLE
Bug in method roundTwoDecimals of the class NumberUtil provoked by locale

### DIFF
--- a/freya/freya-annotate/src/main/java/org/freya/util/NumberUtils.java
+++ b/freya/freya-annotate/src/main/java/org/freya/util/NumberUtils.java
@@ -10,9 +10,9 @@ import java.util.Locale;
  */
 public class NumberUtils {
 	  public static double roundTwoDecimals(double d) {
-		DecimalFormatSymbols decimalSymbols = new DecimalFormatSymbols(Locale.getDefault());
-		decimalSymbols.setDecimalSeparator('.');
-		decimalSymbols.setGroupingSeparator(' ');
+	    DecimalFormatSymbols decimalSymbols = new DecimalFormatSymbols(Locale.getDefault());
+	    decimalSymbols.setDecimalSeparator('.');
+	    decimalSymbols.setGroupingSeparator(' ');
 	    DecimalFormat twoDForm = new DecimalFormat("#.##");
 	    twoDForm.setGroupingUsed(false);
 	    twoDForm.setDecimalFormatSymbols(decimalSymbols);

--- a/freya/freya-annotate/src/main/java/org/freya/util/NumberUtils.java
+++ b/freya/freya-annotate/src/main/java/org/freya/util/NumberUtils.java
@@ -1,14 +1,21 @@
 package org.freya.util;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 /**
  * 
  * @author danica
  *
  */
 public class NumberUtils {
-  public static double roundTwoDecimals(double d) {
-    DecimalFormat twoDForm = new DecimalFormat("#.##");
-    return Double.valueOf(twoDForm.format(d));
-  }
+	  public static double roundTwoDecimals(double d) {
+		DecimalFormatSymbols decimalSymbols = new DecimalFormatSymbols(Locale.getDefault());
+		decimalSymbols.setDecimalSeparator('.');
+		decimalSymbols.setGroupingSeparator(' ');
+	    DecimalFormat twoDForm = new DecimalFormat("#.##");
+	    twoDForm.setGroupingUsed(false);
+	    twoDForm.setDecimalFormatSymbols(decimalSymbols);
+	    return Double.valueOf(twoDForm.format(d));
+	  }
 }


### PR DESCRIPTION
Bug in method roundTwoDecimals ofNumberUtils.java.

A comma may appear instead of a dot as decimal separator depending on the locale configuration. This provokes a number format exception on Double.valueOf. I've added the code to force a dot as decimal separator.